### PR TITLE
Allow a reminder to be updated by its owner

### DIFF
--- a/app/Http/Controllers/RemindersController.php
+++ b/app/Http/Controllers/RemindersController.php
@@ -3,92 +3,47 @@
 namespace App\Http\Controllers;
 
 use App\Reminder;
-use Illuminate\Http\Request;
 use \Symfony\Component\HttpFoundation\Response as ResponseStatusCodes;
 
 class RemindersController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Create a new reminder in the database.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
+    public function store()
     {
         $attributes = request()->validate([
-            'title' => 'required|string|max:31',
-            'description' => 'nullable|string|max:255',
+            'title' => 'required|string|max:50',
+            'description' => 'nullable|string|max:300',
             'notification_date' => 'required|date|after:'.now(),
         ]);
 
         auth()->user()->reminders()->create($attributes);
 
-        return response()->json('The reminder was created successfully!', ResponseStatusCodes::HTTP_CREATED);
+        return response()->json('created', ResponseStatusCodes::HTTP_CREATED);
     }
 
     /**
-     * Display the specified resource.
+     * Update a reminder.
      *
-     * @param  \App\Reminder  $reminder
-     * @return \Illuminate\Http\Response
+     * @param Reminder $reminder
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function show(Reminder $reminder)
+    public function update(Reminder $reminder)
     {
-        //
-    }
+        $this->authorize('update', $reminder);
 
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Reminder  $reminder
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(Reminder $reminder)
-    {
-        //
-    }
+        $attributes = request()->validate([
+            'title' => 'sometimes|required|string|max:50',
+            'description' => 'sometimes|nullable|string|max:300',
+            'notification_date' => 'sometimes|required|date|after:'.now(),
+        ]);
 
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Reminder  $reminder
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, Reminder $reminder)
-    {
-        //
-    }
+        $reminder->update($attributes);
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Reminder  $reminder
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(Reminder $reminder)
-    {
-        //
+        return response()->json('updated', ResponseStatusCodes::HTTP_OK);
     }
 }

--- a/app/Policies/ReminderPolicy.php
+++ b/app/Policies/ReminderPolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Reminder;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ReminderPolicy
+{
+    use HandlesAuthorization;
+
+    public function update(User $user, Reminder $reminder)
+    {
+        return $user->is($reminder->owner);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Reminder;
+use App\Policies\ReminderPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -13,7 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Model' => 'App\Policies\ModelPolicy',
+        Reminder::class => ReminderPolicy::class,
     ];
 
     /**

--- a/app/Reminder.php
+++ b/app/Reminder.php
@@ -16,13 +16,6 @@ class Reminder extends Model
     ];
 
     /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
-    protected $hidden = [];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array
@@ -31,11 +24,31 @@ class Reminder extends Model
         'notification_date' => 'datetime',
     ];
 
+    /**
+     * The path to the reminder.
+     *
+     * @return string
+     */
+    public function path()
+    {
+        return "/reminders/$this->id";
+    }
+
+    /**
+     * The owner of the reminder.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function owner()
     {
         return $this->belongsTo(User::class, 'owner_id');
     }
 
+    /**
+     * The guests of the reminder.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
     public function guests()
     {
         return $this->belongsToMany(User::class, 'reminder_guests');

--- a/app/User.php
+++ b/app/User.php
@@ -37,11 +37,21 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at' => 'datetime',
     ];
 
+    /**
+     * The user's reminders.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function reminders()
     {
         return $this->hasMany(Reminder::class, 'owner_id');
     }
 
+    /**
+     * The reminders in which the user is a guest.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function guestReminders()
     {
         return $this->hasMany(Reminder::class, 'owner_id');

--- a/database/factories/ReminderFactory.php
+++ b/database/factories/ReminderFactory.php
@@ -9,7 +9,7 @@ $factory->define(App\Reminder::class, function (Faker $faker) {
         'description' => $faker->text,
         'notification_date' => now()->addDay(),
         'owner_id' => function () {
-            return factory(User::class)->create()->id;
+            return factory(User::class);
         }
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -16,7 +16,7 @@ use Faker\Generator as Faker;
 
 $factory->define(App\User::class, function (Faker $faker) {
     return [
-        'username' => $faker->name,
+        'username' => $faker->userName,
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
         'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,7 @@
         <env name="MAIL_DRIVER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
     </php>
 </phpunit>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,4 +21,5 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/reminders', 'RemindersController@store');
+    Route::patch('/reminders/{reminder}', 'RemindersController@update');
 });

--- a/tests/Feature/RemindersTest.php
+++ b/tests/Feature/RemindersTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\User;
 use App\Reminder;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -26,23 +25,23 @@ class RemindersTest extends TestCase
     {
         $this->withoutExceptionHandling();
 
-        $this->actingAs(factory(User::class)->create());
+        $this->signIn();
 
         $attributes = [
-            'title' => $this->faker->sentence(4),
-            'description' => $this->faker->text(50),
+            'title' => 'Title',
+            'description' => $this->faker->word,
             'notification_date' => now()->addDay()->toDateString(),
         ];
 
         $this->post('/reminders', $attributes)->assertStatus(Response::HTTP_CREATED);
 
-        $this->assertDatabaseHas('reminders', $attributes);
+        $this->assertDatabaseHas('reminders', ['title' => 'Title']);
     }
 
     /** @test */
     public function a_reminder_requires_a_title()
     {
-        $this->actingAs(factory(User::class)->create());
+        $this->signIn();
 
         $attributes = factory(Reminder::class)->raw(['title' => '']);
 
@@ -52,10 +51,50 @@ class RemindersTest extends TestCase
     /** @test */
     public function a_reminder_requires_a_notification_date()
     {
-        $this->actingAs(factory(User::class)->create());
+        $this->signIn();
 
         $attributes = factory(Reminder::class)->raw(['notification_date' => '']);
 
         $this->post('/reminders', $attributes)->assertSessionHasErrors('notification_date');
+    }
+
+    /** @test */
+    public function a_reminder_requires_a_notification_date_after_the_current_date()
+    {
+        $this->signIn();
+
+        $attributes = factory(Reminder::class)->raw(['notification_date' => now()->subDay()]);
+
+        $this->post('/reminders', $attributes)->assertSessionHasErrors('notification_date');
+    }
+
+    /** @test */
+    public function a_user_can_update_a_reminder()
+    {
+        $this->signIn();
+
+        $attributes = [
+            'title' => 'Reminder A',
+            'description' => $this->faker->text(50),
+            'notification_date' => now()->addDay()->toDateString(),
+        ];
+
+        $reminder = auth()->user()->reminders()->create($attributes);
+
+        $this->patch("/reminders/$reminder->id", ['title' => 'Reminder B'])
+            ->assertStatus(Response::HTTP_OK);
+
+        $this->assertDatabaseHas('reminders', ['title' => 'Reminder B']);
+    }
+
+    /** @test */
+    public function a_user_cannot_update_the_reminders_of_others()
+    {
+        $this->signIn();
+
+        $reminder = factory(Reminder::class)->create();
+
+        $this->patch("/reminders/$reminder->id", ['title' => ''])
+            ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,15 @@
 
 namespace Tests;
 
+use App\User;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function signIn($user = null)
+    {
+        return $this->actingAs($user ?: factory(User::class)->create());
+    }
 }

--- a/tests/Unit/ReminderTest.php
+++ b/tests/Unit/ReminderTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit;
 use App\User;
 use App\Reminder;
 use Tests\TestCase;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ReminderTest extends TestCase
@@ -13,7 +12,7 @@ class ReminderTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function a_reminder_has_only_one_owner()
+    public function it_belongs_to_an_owner()
     {
         $reminder = factory(Reminder::class)->create();
 
@@ -21,10 +20,10 @@ class ReminderTest extends TestCase
     }
 
     /** @test */
-    public function a_reminder_has_many_guests()
+    public function it_has_a_path()
     {
         $reminder = factory(Reminder::class)->create();
 
-        $this->assertInstanceOf(Collection::class, $reminder->guests);
+        $this->assertEquals('/reminders/1', $reminder->path());
     }
 }


### PR DESCRIPTION
This PR implements the ability of an owner to update its own reminders.
It also implements a Policy to enforce that only the owner is capable of updating.
Additionally some code was cleaned up and some dockblocks were added. 

(related to issue #15)